### PR TITLE
Access point test model #6

### DIFF
--- a/app/models/access_point.rb
+++ b/app/models/access_point.rb
@@ -20,4 +20,10 @@
 class AccessPoint < ApplicationRecord
   enum status: { in: 0, out: 1 }
   belongs_to :employee
+
+  validates :check, :employee_id, presence: true
+
+  scope :by_date, -> (date) { where(check: date) }
+  scope :by_month, -> (date) { where(check: date.beginning_of_month..date.end_of_month) }
+  scope :by_employee, -> (employee_id) { where(employee_id: employee_id) }
 end

--- a/spec/factories/access_points.rb
+++ b/spec/factories/access_points.rb
@@ -19,8 +19,20 @@
 #
 FactoryBot.define do
   factory :access_point do
-    check { "2021-04-13 21:29:15" }
-    status { 1 }
-    employee { nil }
+    check { Date.today }
+    status { 0 }
+    employee { create(:employee) }
+
+    trait :out do
+      status { 1 }
+    end
+
+    trait :yesterday do
+      check { Date.yesterday }
+    end
+
+    trait :months_ago do
+      check { 2.month.ago }
+    end
   end
 end

--- a/spec/models/access_point_spec.rb
+++ b/spec/models/access_point_spec.rb
@@ -20,5 +20,40 @@
 require 'rails_helper'
 
 RSpec.describe AccessPoint, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  context 'valid factory' do
+    let!(:employee) { create(:employee) }
+    it { expect(build(:access_point, employee: employee)).to be_valid }
+  end
+
+  describe 'associations' do
+    it { should belong_to(:employee) }
+  end
+
+  describe 'validations' do
+    it { should validate_presence_of(:check) }
+    it { should validate_presence_of(:employee_id) }
+  end
+
+  describe 'scopes' do
+    let!(:employee) { create(:employee) }
+    let!(:access1) { create(:access_point, employee_id: employee.id) }
+    let!(:access2) { create(:access_point, :out , employee_id: employee.id) }
+    let!(:access3) { create(:access_point, :yesterday) }
+    let!(:access4) { create(:access_point, :months_ago) }
+
+    context 'by_date(date)' do
+      it { expect(AccessPoint.by_date(Date.today)).to include(access1, access2) }
+      it { expect(AccessPoint.by_date(Date.today)).not_to include(access3) }
+    end
+
+    context 'by_month(date)' do
+      it { expect(AccessPoint.by_month(Date.today)).to include(access1, access2) }
+      it { expect(AccessPoint.by_month(Date.today)).not_to include(access4)}
+    end
+
+    context 'by_employee' do
+      it { expect(AccessPoint.by_employee(employee.id)).to include(access1, access2) }
+      it { expect(AccessPoint.by_employee(employee.id)).not_to include(access3) }
+    end
+  end
 end


### PR DESCRIPTION
# Description
Add shoulda matchers to test model

- Add testing cases for access point model to validate associations, validations and scopes

- Set the model factory to avoid DRY the test file

- Implemente in the access point model the corresponding associations, validations and scopes

 # Testing
rspec -> to run all the testing cases of the app
rspec spec/model/access_point_spec.rb

